### PR TITLE
ESP8266 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,20 @@ pio run --target upload
 
 You should have something like this:
 ```python
-Building .pio/build/ttgo-display/firmware.bin
-RAM:   [==        ]  19.7% (used 64684 bytes from 327680 bytes)
-Flash: [========= ]  86.4% (used 1698140 bytes from 1966080 bytes)
+Building .pio/build/WEMOS/firmware.bin
+Checking size .pio/build/WEMOS/firmware.elf
+Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
+RAM:   [=         ]  12.3% (used 40432 bytes from 327680 bytes)
+Flash: [======    ]  64.9% (used 850800 bytes from 1310720 bytes)
 esptool.py v2.6
-============== [SUCCESS] Took 33.86 seconds ==================
+===================== [SUCCESS] Took 8.44 seconds =======================
 
-Environment       Status    Duration
-----------------  --------  ------------
-ttgo-display      SUCCESS   00:00:33.861
-ttgo-display-ota  IGNORED
-============= 1 succeeded in 00:00:33.861 =====================
+Environment    Status    Duration
+-------------  --------  ------------
+WEMOS          SUCCESS   00:00:08.441
+TTGO_T7        IGNORED
+nodemcuv2      IGNORED
+===================== 1 succeeded in 00:00:08.441 ========================
 ```
 
 Only in the first time, please upload the config file too:

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ framework = arduino
 upload_speed = 1500000
 monitor_speed = 115200
 build_flags =
-    -D SRC_REV=0012
+    -D SRC_REV=0031
 
 lib_deps = 
       https://github.com/hpsaturn/WiFiManager.git#development

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,8 @@ lib_deps =
       ${common_env_data.lib_deps}
 
 [env:esp12e]
-platform = https://github.com/platformio/platform-espressif8266.git
+platform = espressif8266
+; platform = https://github.com/platformio/platform-espressif8266.git
 framework = ${common_env_data.framework}
 board = esp12e
 build_flags =

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ build_flags =
 lib_deps = 
       https://github.com/hpsaturn/WiFiManager.git#development
       ArduinoJson
-      ESP32Ping
+      ; ESP32Ping
 
 [env:WEMOS]
 platform = espressif32
@@ -48,8 +48,16 @@ lib_deps =
 
 [env:nodemcuv2]
 platform = espressif8266
-framework = ${common_env_data.framework}
 board = nodemcuv2
+build_flags =
+      ${common_env_data.build_flags}
+lib_deps = 
+      ${common_env_data.lib_deps}
+
+[env:esp12e]
+platform = https://github.com/platformio/platform-espressif8266.git
+framework = ${common_env_data.framework}
+board = esp12e
 build_flags =
       ${common_env_data.build_flags}
 lib_deps = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,6 @@ build_flags =
 lib_deps = 
       https://github.com/hpsaturn/WiFiManager.git#development
       ArduinoJson
-      ; ESP32Ping
 
 [env:WEMOS]
 platform = espressif32
@@ -34,6 +33,7 @@ build_flags =
       ${common_env_data.build_flags}
 lib_deps = 
       ${common_env_data.lib_deps}
+      ESP32Ping
 
 [env:TTGO_T7]
 platform = espressif32
@@ -45,6 +45,7 @@ build_flags =
       ${common_env_data.build_flags}
 lib_deps = 
       ${common_env_data.lib_deps}
+      ESP32Ping
 
 [env:nodemcuv2]
 platform = espressif8266
@@ -53,6 +54,7 @@ build_flags =
       ${common_env_data.build_flags}
 lib_deps = 
       ${common_env_data.lib_deps}
+      ESP8266Ping
 
 [env:esp12e]
 platform = espressif8266
@@ -63,3 +65,4 @@ build_flags =
       ${common_env_data.build_flags}
 lib_deps = 
       ${common_env_data.lib_deps}
+      ESP8266Ping

--- a/platformio.ini
+++ b/platformio.ini
@@ -49,6 +49,7 @@ lib_deps =
 
 [env:nodemcuv2]
 platform = espressif8266
+framework = ${common_env_data.framework}
 board = nodemcuv2
 build_flags =
       ${common_env_data.build_flags}
@@ -58,7 +59,6 @@ lib_deps =
 
 [env:esp12e]
 platform = espressif8266
-; platform = https://github.com/platformio/platform-espressif8266.git
 framework = ${common_env_data.framework}
 board = esp12e
 build_flags =

--- a/src/WiFiConnect.cpp
+++ b/src/WiFiConnect.cpp
@@ -134,7 +134,7 @@ void startWifiManager() {
     // always start configportal for a little while
     wm.setConfigPortalTimeout(PORTAL_TIMEOUT);
     wm.startConfigPortal("CanAirIO Config", "CanAirIO");
-    WiFi.setHostname("CanAirIO");
+    // WiFi.setHostname("CanAirIO");
     portal_running=true;
 }
 

--- a/src/WiFiConnect.cpp
+++ b/src/WiFiConnect.cpp
@@ -151,6 +151,7 @@ void setupWifiManager() {
     wm.setConfigPortalBlocking(false);
     //set config save notify callback
     wm.setSaveConfigCallback(saveConfigCallback);
+    wm.setEnableConfigPortal(true);
 }
 
 int keepAliveTick;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 #include <WiFiConnect.hpp>  // Abstraction and handler of WifiManager
-// #include <ESP32Ping.h>      // Only for tests
+#include <ESP32Ping.h>      // Only for tests
+// #include <ESP8266Ping.h>
 
 #define GPIO_LED_GREEN          22  // Led on TTGO board (black)
-
 
 void blinkOnboardLed() {
     digitalWrite(GPIO_LED_GREEN, LOW);
@@ -11,12 +11,14 @@ void blinkOnboardLed() {
 }
 
 void runPingTest() {
-    // if (Ping.ping(getConfig().influx_server)) {
-    //     blinkOnboardLed();
-    //     Serial.println(" -> Success!!");
-    // } else {
-    //     Serial.println(" -> Error :(");
-    // }
+    Serial.print(">VD: Pinging:\t");
+    Serial.print(getConfig().influx_server);
+    if (Ping.ping(getConfig().influx_server)) {
+        blinkOnboardLed();
+        Serial.println(" -> Success!!");
+    } else {
+        Serial.println(" -> Error :(");
+    }
 }
 
 void setup() {
@@ -44,9 +46,7 @@ void loop() {
     }
     if(WiFi.isConnected()) {
         if(millis() - timeStamp > APP_REFRESH_TIME*1000) {   
-            // runPingTest();                    // <== Application code running here
-            Serial.print(">VD: Pinging:\t");
-            Serial.println(getConfig().influx_server);
+            runPingTest();                    // <== Application code running here
             keepAlivePortal();                // validate if portal should be on
             timeStamp = millis();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,9 +11,6 @@ void blinkOnboardLed() {
 }
 
 void runPingTest() {
-    Serial.print(">VD: Pinging:\t");
-    Serial.print(getConfig().influx_server);
-
     // if (Ping.ping(getConfig().influx_server)) {
     //     blinkOnboardLed();
     //     Serial.println(" -> Success!!");
@@ -48,6 +45,8 @@ void loop() {
     if(WiFi.isConnected()) {
         if(millis() - timeStamp > APP_REFRESH_TIME*1000) {   
             // runPingTest();                    // <== Application code running here
+            Serial.print(">VD: Pinging:\t");
+            Serial.println(getConfig().influx_server);
             keepAlivePortal();                // validate if portal should be on
             timeStamp = millis();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,9 +6,11 @@
 #include <ESP8266Ping.h>
 #endif
 
-
-
+#ifdef TTGO_T7
 #define GPIO_LED_GREEN          22  // Led on TTGO board (black)
+#else
+#define GPIO_LED_GREEN          LED_BUILTIN
+#endif
 
 void blinkOnboardLed() {
     digitalWrite(GPIO_LED_GREEN, LOW);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 #include <WiFiConnect.hpp>  // Abstraction and handler of WifiManager
-#include <ESP32Ping.h>      // Only for tests
+// #include <ESP32Ping.h>      // Only for tests
 
 #define GPIO_LED_GREEN          22  // Led on TTGO board (black)
 
@@ -14,12 +14,12 @@ void runPingTest() {
     Serial.print(">VD: Pinging:\t");
     Serial.print(getConfig().influx_server);
 
-    if (Ping.ping(getConfig().influx_server)) {
-        blinkOnboardLed();
-        Serial.println(" -> Success!!");
-    } else {
-        Serial.println(" -> Error :(");
-    }
+    // if (Ping.ping(getConfig().influx_server)) {
+    //     blinkOnboardLed();
+    //     Serial.println(" -> Success!!");
+    // } else {
+    //     Serial.println(" -> Error :(");
+    // }
 }
 
 void setup() {
@@ -47,7 +47,7 @@ void loop() {
     }
     if(WiFi.isConnected()) {
         if(millis() - timeStamp > APP_REFRESH_TIME*1000) {   
-            runPingTest();                    // <== Application code running here
+            // runPingTest();                    // <== Application code running here
             keepAlivePortal();                // validate if portal should be on
             timeStamp = millis();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,12 @@
 #include <WiFiConnect.hpp>  // Abstraction and handler of WifiManager
+
+#ifdef ESP32
 #include <ESP32Ping.h>      // Only for tests
-// #include <ESP8266Ping.h>
+#elif ESP8266
+#include <ESP8266Ping.h>
+#endif
+
+
 
 #define GPIO_LED_GREEN          22  // Led on TTGO board (black)
 


### PR DESCRIPTION
Ready basic support for ESP32/8266 ping test version. Supported boards:

WEMOS, NodeMCU v2, TTGO T7, ESP12e (D1Mini)